### PR TITLE
allow running without zookeeper, add cerulean86 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "museum_site/static/cerulean86"]
+	path = museum_site/static/cerulean86
+	url = https://github.com/asiekierka/cerulean86-z2

--- a/museum_api/endpoints.py
+++ b/museum_api/endpoints.py
@@ -14,13 +14,20 @@ from museum_site.models import (
 
 from museum_site.common import *
 
-import zookeeper
+try:
+    import zookeeper
+    HAS_ZOOKEEPER = True
+except ImportError:
+    HAS_ZOOKEEPER = False
 
 
 from django.http import JsonResponse
 
 # Create your views here.
 def worlds_of_zzt(request):
+    if not HAS_ZOOKEEPER:
+        return server_error_500(request)
+
     # Timestamp
     ts = int(time.time())
 

--- a/museum_site/common.py
+++ b/museum_site/common.py
@@ -157,6 +157,13 @@ CUSTOM_CHARSET_LIST = (
     "2359-ZZFACES.png",
 )
 
+CUSTOM_CHARSET_MAP = {}
+for charset_name in CUSTOM_CHARSET_LIST:
+    try:
+        CUSTOM_CHARSET_MAP[int(charset_name.split('-', 1)[0])] = charset_name
+    except ValueError:
+        pass
+
 DETAIL_LIST = (
     "Contest"
     "Etc."

--- a/museum_site/models.py
+++ b/museum_site/models.py
@@ -358,6 +358,9 @@ class File(models.Model):
     def play_url(self):
         return "/play/" + self.letter + "/" + self.filename
 
+    def play_builtin_url(self):
+        return "/play/builtin/" + self.letter + "/" + self.filename
+
     def review_url(self):
         return "/review/" + self.letter + "/" + self.filename
 
@@ -393,6 +396,17 @@ class File(models.Model):
     def is_uploaded(self):
         uploaded = self.details.all().values_list("id", flat=True)
         return True if DETAIL_UPLOADED in uploaded else False
+
+    def is_zzt(self):
+        lost = self.details.all().values_list("id", flat=True)
+        return True if DETAIL_ZZT in lost else False
+
+    def is_super_zzt(self):
+        lost = self.details.all().values_list("id", flat=True)
+        return True if DETAIL_SZZT in lost else False
+
+    def supports_builtin_player(self):
+        return self.id != 85 and (self.is_zzt() or self.is_super_zzt())
 
     def recalculate_reviews(self):
         # Recalculate Review Count

--- a/museum_site/static/css/style.css
+++ b/museum_site/static/css/style.css
@@ -674,7 +674,7 @@ div.file-details ul
     /*min-height:400px;*/
 }
 
-#play-area iframe
+#play-area iframe, #play-area canvas
 {
     margin:auto;
 }

--- a/museum_site/templates/museum_site/blocks/file_links.html
+++ b/museum_site/templates/museum_site/blocks/file_links.html
@@ -1,5 +1,11 @@
 <div{% if file.is_lost %} class="hidden"{% endif %}><a href="{{file.download_url}}">Download</a></div>
+{% if file.supports_builtin_player %}
+<div{% if file.is_lost %} class="hidden"{% endif %}><a href="{{file.play_builtin_url}}">Play Online</a> (Beta!,
+    <a{% if file.is_lost or file.is_uploaded %} class="hidden"{% endif %} href="{{file.play_url}}">Archive</a>)
+</div>
+{% else %}
 <div{% if file.is_lost or file.is_uploaded %} class="hidden"{% endif %}><a href="{{file.play_url}}">Play Online</a></div>
+{% endif %}
 <div{% if file.is_uploaded %} class="hidden"{% endif %}><a href="{{file.review_url}}">Reviews ({{file.review_count|default:0}})</a></div>
 <div{% if file.is_lost %} class="hidden"{% endif %}><a href="{{file.file_url}}">View Files</a></div>
 <div{% if file.is_uploaded %} class="hidden"{% endif %}><a href="{{file.article_url}}">Articles ({{file.article_count|default:0}})</a></div>

--- a/museum_site/templates/museum_site/browse_list.html
+++ b/museum_site/templates/museum_site/browse_list.html
@@ -31,7 +31,7 @@
         <td class="size">{{file.size}} KB</td>
         <td class="rating">{%if file.rating != None %}<span title="Based on {{file.review_count}} review{{file.review_count|pluralize}}">{{file.rating|floatformat:"2"}} / 5.00</span>{% else %}<em>None</em>{% endif %}</td>
         <td class="files"><a href="{{file.file_url}}">View</a></td>
-        <td class="files"><a href="{{file.play_url}}">Play</a></td>
+        <td class="files"><a href="{{file.play_builtin_url}}">Play</a></td>
         {% comment %}<td class="wiki"><a href="{{file.wiki_url}}">Wiki</a></td>{% endcomment %}
     </tr>
 {% endfor %}

--- a/museum_site/templates/museum_site/play_builtin.html
+++ b/museum_site/templates/museum_site/play_builtin.html
@@ -1,0 +1,33 @@
+{% extends "museum_site/world.html" %}
+
+{% block scripts %}
+<script type="text/javascript" src="/static/cerulean86/zzt_preload.js"></script>
+<script type="text/javascript">
+    window.onload = function() {
+        zzt_emu_load("/static/cerulean86/", {
+            files: [
+            {% if file.is_super_zzt %}
+                "/static/cerulean86_engines/szzt.zip",
+            {% else %}
+                "/static/cerulean86_engines/zzt.zip",
+            {% endif %}
+            "{{file.download_url}}"],
+            charset_png:
+            {% if custom_charset %}
+                "/static/images/charsets/{{custom_charset}}"
+            {% else %}
+                "/static/images/charsets/cp437.png"
+            {% endif %}
+        });
+    };
+</script>
+{% endblock %}
+
+{% block world_content %}
+<div id="play-area">
+    <canvas id="zzt_canvas" width="640" height="350"></canvas>
+</div>
+
+<div>
+</div>
+{% endblock %}

--- a/museum_site/tools.py
+++ b/museum_site/tools.py
@@ -6,7 +6,11 @@ from django.shortcuts import render
 from .common import *
 from zipfile import ZipFile
 
-import zookeeper
+try:
+    import zookeeper
+    HAS_ZOOKEEPER = True
+except ImportError:
+    HAS_ZOOKEEPER = False
 
 
 @staff_member_required
@@ -89,6 +93,9 @@ def set_screenshot(request, pk):
     file = File.objects.get(pk=pk)
     data["file"] = file
     data["file_list"] = []
+
+    if not HAS_ZOOKEEPER:
+        return server_error_500(request)
 
     with ZipFile(SITE_ROOT + file.download_url(), "r") as zf:
         all_files = zf.namelist()

--- a/museum_site/urls.py
+++ b/museum_site/urls.py
@@ -88,6 +88,9 @@ urlpatterns = [
     url(r"^play/(?P<letter>[a-z1!])/(?P<filename>.*)$", museum_site.views.play,
         name="play"
         ),
+    url(r"^play/builtin/(?P<letter>[a-z1!])/(?P<filename>.*)$", museum_site.views.play_builtin,
+        name="play_builtin"
+        ),
     url(r"^file/local$", museum_site.views.file,
         {"local": True, "letter":"!", "filename":""},
         name="local",

--- a/museum_site/views.py
+++ b/museum_site/views.py
@@ -396,6 +396,29 @@ def play(request, letter, filename):
     return render(request, "museum_site/play.html", data)
 
 
+def play_builtin(request, letter, filename):
+    """ Returns page to play file via built-in emulation """
+    data = {}
+    data["file"] = File.objects.filter(letter=letter, filename=filename)
+    if len(data["file"]) == 0:
+        raise Http404()
+    elif len(data["file"]) > 1:
+        for file in data["file"]:
+            if file.filename == filename:
+                data["file"] = file
+                break
+    else:
+        data["file"] = data["file"][0]
+    data["title"] = data["file"].title + " - Play Online"
+    data["letter"] = letter
+    if data["file"].id in CUSTOM_CHARSET_MAP:
+        data["custom_charset"] = CUSTOM_CHARSET_MAP[data["file"].id]
+    else:
+        data["custom_charset"] = None
+
+    return render(request, "museum_site/play_builtin.html", data)
+
+
 def random(request):
     """ Returns a random ZZT file page """
     max_pk = File.objects.all().order_by("-id")[0].id


### PR DESCRIPTION
Please keep in mind this adds a Git submodule for cerulean86 - this is to more cleanly separate it from the rest of the project.

Also, /static/cerulean86_engines (feel free to change it in play_builtin.html) expects two files:

* http://asie.pl/files/szzt.zip (Super ZZT engine)
* http://asie.pl/files/zzt.zip (ZZT 3.2 engine)